### PR TITLE
Simplfying code of norm_layer

### DIFF
--- a/models/modules/modules.py
+++ b/models/modules/modules.py
@@ -171,43 +171,43 @@ class InceptionDown(nn.Module):
         ## LEVEL 0
         self.conv0_1x1_0 = nn.Conv2d(in_channels, intermediate, 1,
                                     stride, 0, dilation, groups, bias)
-        self.bconv0_1x1_0 = norm_layer(intermediate, affine=True)
+        self.bconv0_1x1_0 = norm_layer(intermediate)
 
         self.conv0_1x1_1 = nn.Conv2d(in_channels, intermediate, 1,
                                     stride, 0, dilation, groups, bias)
-        self.bconv0_1x1_1 = norm_layer(intermediate, affine=True)
+        self.bconv0_1x1_1 = norm_layer(intermediate)
 
         self.max_pool0 = nn.MaxPool2d(2, 2)
 
         self.conv0_1x1_2 = nn.Conv2d(in_channels, out_channels, 1,
                                     stride, 0, dilation, groups, bias)
-        self.bconv0_1x1_2 = norm_layer(out_channels, affine=True)
+        self.bconv0_1x1_2 = norm_layer(out_channels)
 
         ## LEVEL 2
         self.conv1_3x3 = nn.Conv2d(intermediate, intermediate, 3,
                                     stride, 1, dilation, groups, bias)
-        self.bconv1_3x3 = norm_layer(intermediate, affine=True)
+        self.bconv1_3x3 = norm_layer(intermediate)
 
         self.conv1_1x3 = nn.Conv2d(intermediate, out_channels, (1, 3),
                                     stride, (0, 1), dilation, groups, bias)
-        self.bconv1_1x3 = norm_layer(out_channels, affine=True)
+        self.bconv1_1x3 = norm_layer(out_channels)
 
         self.conv1_3x1 = nn.Conv2d(intermediate, out_channels, (3, 1),
                                     stride, (1, 0), dilation, groups, bias)
-        self.bconv1_3x1 = norm_layer(out_channels, affine=True)
+        self.bconv1_3x1 = norm_layer(out_channels)
 
         self.conv1_1x1 = nn.Conv2d(in_channels, out_channels, 1,
                                     stride, 0, dilation, groups, bias)
-        self.bconv1_1x1 = norm_layer(out_channels, affine=True)
+        self.bconv1_1x1 = norm_layer(out_channels)
 
         ## LEVEL 3
         self.conv2_1x3 = nn.Conv2d(intermediate, out_channels, (1, 3),
                                    stride, (0, 1), dilation, groups, bias)
-        self.bconv2_1x3 = norm_layer(out_channels, affine=True)
+        self.bconv2_1x3 = norm_layer(out_channels)
 
         self.conv2_3x1 = nn.Conv2d(intermediate, out_channels, (3, 1),
                                    stride, (1, 0), dilation, groups, bias)
-        self.bconv2_3x1 = norm_layer(out_channels, affine=True)
+        self.bconv2_3x1 = norm_layer(out_channels)
 
     def _forward(self, input, conv, normalization):
         #print(self.in_channels, self.out_channels, input.shape)
@@ -300,35 +300,35 @@ class InceptionUp(nn.Module):
         self.conv0_1x1_0 = nn.ConvTranspose2d(in_channels, out_channels, 1,
                                               stride=2, padding=0, output_padding=1,
                                               groups=1, bias=True, dilation=1)
-        self.bconv0_1x1_0 = norm_layer(out_channels, affine=True)
+        self.bconv0_1x1_0 = norm_layer(out_channels)
 
         self.conv0_1x1_1 = nn.ConvTranspose2d(in_channels, intermediate, 1,
                                               stride=2, padding=0, output_padding=1,
                                               groups=1, bias=True, dilation=1)
-        self.bconv0_1x1_1 = norm_layer(intermediate, affine=True)
+        self.bconv0_1x1_1 = norm_layer(intermediate)
 
         self.upsample0 = nn.Upsample(scale_factor=2, mode='bilinear')
 
         self.conv0_1x1_2 = nn.ConvTranspose2d(in_channels, intermediate, 1,
                                               stride=2, padding=0, output_padding=1,
                                               groups=1, bias=True, dilation=1)
-        self.bconv0_1x1_2 = norm_layer(intermediate, affine=True)
+        self.bconv0_1x1_2 = norm_layer(intermediate)
 
         ## LEVEL 2
         self.conv1_3x3 = nn.ConvTranspose2d(intermediate, out_channels, 3,
                                               stride=1, padding=1, output_padding=0,
                                               groups=1, bias=True, dilation=1)
-        self.bconv1_3x3 = norm_layer(out_channels, affine=True)
+        self.bconv1_3x3 = norm_layer(out_channels)
 
         self.conv1_5x5 = nn.ConvTranspose2d(intermediate, out_channels, 5,
                                               stride=1, padding=2, output_padding=0,
                                               groups=1, bias=True, dilation=1)
-        self.bconv1_5x5 = norm_layer(out_channels, affine=True)
+        self.bconv1_5x5 = norm_layer(out_channels)
 
         self.conv1_1x1 = nn.ConvTranspose2d(in_channels, out_channels, 1,
                                               stride=1, padding=0, output_padding=0,
                                               groups=1, bias=True, dilation=1)
-        self.bconv1_1x1 = norm_layer(out_channels, affine=True)
+        self.bconv1_1x1 = norm_layer(out_channels)
 
     def _forward(self, input, conv, normalization):
         #print(self.in_channels, self.out_channels, input.shape)

--- a/models/modules/shift_unet.py
+++ b/models/modules/shift_unet.py
@@ -73,9 +73,9 @@ class UnetSkipConnectionShiftBlock(nn.Module):
         downconv = nn.Conv2d(input_nc, inner_nc, kernel_size=4,
                              stride=2, padding=1)
         downrelu = nn.LeakyReLU(0.2, True)
-        downnorm = norm_layer(inner_nc, affine=True)
+        downnorm = norm_layer(inner_nc)
         uprelu = nn.ReLU(True)
-        upnorm = norm_layer(outer_nc, affine=True)
+        upnorm = norm_layer(outer_nc)
 
         # As the downconv layer is outer_nc in and inner_nc out.
         # So the shift define like this:
@@ -188,9 +188,9 @@ class ResUnetSkipConnectionBlock(nn.Module):
         downconv = nn.Conv2d(input_nc, inner_nc, kernel_size=4,
                              stride=2, padding=1)
         downrelu = nn.LeakyReLU(0.2, True)
-        downnorm = norm_layer(inner_nc, affine=True)
+        downnorm = norm_layer(inner_nc)
         uprelu = nn.ReLU(True)
-        upnorm = norm_layer(outer_nc, affine=True)
+        upnorm = norm_layer(outer_nc)
 
         # As the downconv layer is outer_nc in and inner_nc out.
         # So the shift define like this:
@@ -300,9 +300,9 @@ class SoftUnetSkipConnectionBlock(nn.Module):
         downconv = nn.Conv2d(input_nc, inner_nc, kernel_size=4,
                              stride=2, padding=1)
         downrelu = nn.LeakyReLU(0.2, True)
-        downnorm = norm_layer(inner_nc, affine=True)
+        downnorm = norm_layer(inner_nc)
         uprelu = nn.ReLU(True)
-        upnorm = norm_layer(outer_nc, affine=True)
+        upnorm = norm_layer(outer_nc)
 
         # As the downconv layer is outer_nc in and inner_nc out.
         # So the shift define like this:
@@ -415,9 +415,9 @@ class PatchSoftUnetSkipConnectionShiftTriple(nn.Module):
         downconv = nn.Conv2d(input_nc, inner_nc, kernel_size=4,
                              stride=2, padding=1)
         downrelu = nn.LeakyReLU(0.2, True)
-        downnorm = norm_layer(inner_nc, affine=True)
+        downnorm = norm_layer(inner_nc)
         uprelu = nn.ReLU(True)
-        upnorm = norm_layer(outer_nc, affine=True)
+        upnorm = norm_layer(outer_nc)
 
         # As the downconv layer is outer_nc in and inner_nc out.
         # So the shift define like this:
@@ -531,9 +531,9 @@ class ResPatchSoftUnetSkipConnectionShiftTriple(nn.Module):
         downconv = nn.Conv2d(input_nc, inner_nc, kernel_size=4,
                              stride=2, padding=1)
         downrelu = nn.LeakyReLU(0.2, True)
-        downnorm = norm_layer(inner_nc, affine=True)
+        downnorm = norm_layer(inner_nc)
         uprelu = nn.ReLU(True)
-        upnorm = norm_layer(outer_nc, affine=True)
+        upnorm = norm_layer(outer_nc)
 
         # As the downconv layer is outer_nc in and inner_nc out.
         # So the shift define like this:
@@ -646,9 +646,9 @@ class InceptionUnetSkipConnectionBlock(nn.Module):
 
 
         downrelu = nn.LeakyReLU(0.2, True)
-        downnorm = norm_layer(inner_nc, affine=True)
+        downnorm = norm_layer(inner_nc)
         uprelu = nn.ReLU(True)
-        upnorm = norm_layer(outer_nc, affine=True)
+        upnorm = norm_layer(outer_nc)
 
         # Different position only has differences in `upconv`
         # for the outermost, the special is `tanh`
@@ -722,9 +722,9 @@ class InceptionShiftUnetSkipConnectionBlock(nn.Module):
         downconv = InceptionDown(input_nc, inner_nc) # nn.Conv2d(input_nc, inner_nc, kernel_size=4,stride=2, padding=1)
 
         downrelu = nn.LeakyReLU(0.2, True)
-        downnorm = norm_layer(inner_nc, affine=True)
+        downnorm = norm_layer(inner_nc)
         uprelu = nn.ReLU(True)
-        upnorm = norm_layer(outer_nc, affine=True)
+        upnorm = norm_layer(outer_nc)
 
         # Different position only has differences in `upconv`
         # for the outermost, the special is `tanh`

--- a/models/modules/unet.py
+++ b/models/modules/unet.py
@@ -41,9 +41,9 @@ class UnetSkipConnectionBlock(nn.Module):
         downconv = nn.Conv2d(input_nc, inner_nc, kernel_size=4,
                              stride=2, padding=1)
         downrelu = nn.LeakyReLU(0.2, True)
-        downnorm = norm_layer(inner_nc, affine=True)
+        downnorm = norm_layer(inner_nc)
         uprelu = nn.ReLU(True)
-        upnorm = norm_layer(outer_nc, affine=True)
+        upnorm = norm_layer(outer_nc)
 
         # Different position only has differences in `upconv`
             # for the outermost, the special is `tanh`

--- a/models/networks.py
+++ b/models/networks.py
@@ -10,9 +10,9 @@ from .modules import *
 ###############################################################################
 def get_norm_layer(norm_type='instance'):
     if norm_type == 'batch':
-        norm_layer = functools.partial(nn.BatchNorm2d, affine=True)
+        norm_layer = functools.partial(nn.BatchNorm2d, affine=True, track_running_stats=True)
     elif norm_type == 'instance':
-        norm_layer = functools.partial(nn.InstanceNorm2d, affine=True)
+        norm_layer = functools.partial(nn.InstanceNorm2d, affine=False, track_running_stats=False)
     elif norm_type == 'none':
         norm_layer = None
     else:

--- a/models/networks.py
+++ b/models/networks.py
@@ -12,7 +12,7 @@ def get_norm_layer(norm_type='instance'):
     if norm_type == 'batch':
         norm_layer = functools.partial(nn.BatchNorm2d, affine=True, track_running_stats=True)
     elif norm_type == 'instance':
-        norm_layer = functools.partial(nn.InstanceNorm2d, affine=False, track_running_stats=False)
+        norm_layer = functools.partial(nn.InstanceNorm2d, affine=True, track_running_stats=False)
     elif norm_type == 'none':
         norm_layer = None
     else:


### PR DESCRIPTION
I have found that original cyclegan or other inpainting paper (eg, EdgeConnect) using InstanceNorm with 'affine=False'. However,
- If your use InstanceNorm with affine=True, then its performance is better than that of affine=False.
- When Batchsize>1, its results are a little bit inferior to that of batchsize=1 for InstanceNorm.
- However, for BN, batchsize>1 gives very bad results.(For this case, we need set the model eval mode.  While when using IN, we do not set the model eval mode.)

Therefore, I keep affine=True for InstanceNorm. Mention: the default setting for InstanceNorm is 'affine=False and track_running_stats=False'. That is to say, I keep the original setting of IN with `affine=True and track_running_stats=False`