### PR TITLE
Delete fixed_mask option

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,6 @@ DO NOT change the shift_sz and mask_thred. Otherwise, it errors with a high prob
 
 For `patch soft shift-net` or `res patch soft shift-net`. You may set `fuse=1` to see whether it delivers better results.
 
-**If you want to train model with `random` masks, you need to set `fixed_mask=0` and `mask_type='random'.`**.
-Yes, it is a little bit troublesome, I will delete `fixed_masked` option later when I rebase the code next week.
-
 - To view training results and loss plots, run `python -m visdom.server` and click the URL http://localhost:8097. The checkpoints will be saved in `./log` by default.
 
 - Test the model

--- a/models/modules/shift_unet.py
+++ b/models/modules/shift_unet.py
@@ -79,7 +79,7 @@ class UnetSkipConnectionShiftBlock(nn.Module):
 
         # As the downconv layer is outer_nc in and inner_nc out.
         # So the shift define like this:
-        shift = InnerShiftTriple(opt.fixed_mask, opt.shift_sz, opt.stride, opt.mask_thred,
+        shift = InnerShiftTriple(opt.shift_sz, opt.stride, opt.mask_thred,
                                             opt.triple_weight)
 
         shift.set_mask(mask_global, 3)
@@ -194,7 +194,7 @@ class ResUnetSkipConnectionBlock(nn.Module):
 
         # As the downconv layer is outer_nc in and inner_nc out.
         # So the shift define like this:
-        shift = InnerResShiftTriple(opt.fixed_mask, inner_nc, opt.shift_sz, opt.stride, opt.mask_thred,
+        shift = InnerResShiftTriple(inner_nc, opt.shift_sz, opt.stride, opt.mask_thred,
                                             opt.triple_weight)
 
         shift.set_mask(mask_global, 3)
@@ -306,7 +306,7 @@ class SoftUnetSkipConnectionBlock(nn.Module):
 
         # As the downconv layer is outer_nc in and inner_nc out.
         # So the shift define like this:
-        shift = InnerSoftShiftTriple(opt.fixed_mask, opt.shift_sz, opt.stride, opt.mask_thred, opt.triple_weight)
+        shift = InnerSoftShiftTriple(opt.shift_sz, opt.stride, opt.mask_thred, opt.triple_weight)
 
         shift.set_mask(mask_global, 3)
         shift_list.append(shift)
@@ -708,7 +708,7 @@ class InceptionShiftUnetSkipConnectionBlock(nn.Module):
         if shift_layer:
             # As the downconv layer is outer_nc in and inner_nc out.
             # So the shift define like this:
-            shift = InnerShiftTriple(opt.fixed_mask, opt.shift_sz, opt.stride, opt.mask_thred, opt.triple_weight)
+            shift = InnerShiftTriple(opt.shift_sz, opt.stride, opt.mask_thred, opt.triple_weight)
 
             shift.set_mask(mask_global, 3)
             shift_list.append(shift)

--- a/models/res_shift_net/innerResShiftTriple.py
+++ b/models/res_shift_net/innerResShiftTriple.py
@@ -5,15 +5,13 @@ import util.util as util
 from models.shift_net.InnerShiftTripleFunction import InnerShiftTripleFunction
 
 class InnerResShiftTriple(nn.Module):
-    def __init__(self, fixed_mask, inner_nc, shift_sz=1, stride=1, mask_thred=1, triple_weight=1):
+    def __init__(self, inner_nc, shift_sz=1, stride=1, mask_thred=1, triple_weight=1):
         super(InnerResShiftTriple, self).__init__()
-        self.fixed_mask = fixed_mask
 
         self.shift_sz = shift_sz
         self.stride = stride
         self.mask_thred = mask_thred
         self.triple_weight = triple_weight
-        self.cal_fixed_flag = True # whether we need to calculate the temp varaiables this time.
         self.show_flow = False # default false. Do not change it to be true, it is computation-heavy.
         self.flow_srcs = None # Indicating the flow src(pixles in non-masked region that will shift into the masked region)
 
@@ -37,13 +35,9 @@ class InnerResShiftTriple(nn.Module):
     def forward(self, input):
         #print(input.shape)
         _, self.c, self.h, self.w = input.size()
-        if self.fixed_mask and self.cal_fixed_flag == False:
-            assert torch.is_tensor(self.flag), 'flag must have been figured out and has to be a tensor!'
-        else:
-            latter = input.narrow(1, self.c//2, self.c//2).narrow(0,0,1).detach()
-            self.flag = util.cal_flag_given_mask_thred(latter.squeeze(), self.mask, self.shift_sz, \
-                                                                                                   self.stride, self.mask_thred)
-            self.cal_fixed_flag = False
+        latter = input.narrow(1, self.c//2, self.c//2).narrow(0,0,1).detach()
+        self.flag = util.cal_flag_given_mask_thred(latter.squeeze(), self.mask, self.shift_sz, \
+                                                                                                self.stride, self.mask_thred)
 
         shift_out = InnerShiftTripleFunction.apply(input, self.mask, self.shift_sz, self.stride, self.triple_weight, self.flag, self.show_flow)
 

--- a/models/res_shift_net/innerResShiftTriple.py
+++ b/models/res_shift_net/innerResShiftTriple.py
@@ -35,9 +35,7 @@ class InnerResShiftTriple(nn.Module):
     def forward(self, input):
         #print(input.shape)
         _, self.c, self.h, self.w = input.size()
-        latter = input.narrow(1, self.c//2, self.c//2).narrow(0,0,1).detach()
-        self.flag = util.cal_flag_given_mask_thred(latter.squeeze(), self.mask, self.shift_sz, \
-                                                                                                self.stride, self.mask_thred)
+        self.flag = util.cal_flag_given_mask_thred(self.mask, self.shift_sz, self.stride, self.mask_thred)
 
         shift_out = InnerShiftTripleFunction.apply(input, self.mask, self.shift_sz, self.stride, self.triple_weight, self.flag, self.show_flow)
 

--- a/models/shift_net/InnerShiftTriple.py
+++ b/models/shift_net/InnerShiftTriple.py
@@ -24,9 +24,7 @@ class InnerShiftTriple(nn.Module):
     def forward(self, input):
         #print(input.shape)
         _, self.c, self.h, self.w = input.size()
-        latter = input.narrow(1, self.c//2, self.c//2).narrow(0,0,1).detach()
-        self.flag = util.cal_flag_given_mask_thred(latter.squeeze(), self.mask, self.shift_sz, \
-                                                                                                self.stride, self.mask_thred)
+        self.flag = util.cal_flag_given_mask_thred(self.mask, self.shift_sz, self.stride, self.mask_thred)
 
         final_out = InnerShiftTripleFunction.apply(input, self.mask, self.shift_sz, self.stride, self.triple_weight, self.flag, self.show_flow)
         if self.show_flow:

--- a/models/shift_net/InnerShiftTriple.py
+++ b/models/shift_net/InnerShiftTriple.py
@@ -4,15 +4,13 @@ import util.util as util
 from .InnerShiftTripleFunction import InnerShiftTripleFunction
 
 class InnerShiftTriple(nn.Module):
-    def __init__(self, fixed_mask, shift_sz=1, stride=1, mask_thred=1, triple_weight=1):
+    def __init__(self, shift_sz=1, stride=1, mask_thred=1, triple_weight=1):
         super(InnerShiftTriple, self).__init__()
-        self.fixed_mask = fixed_mask
 
         self.shift_sz = shift_sz
         self.stride = stride
         self.mask_thred = mask_thred
         self.triple_weight = triple_weight
-        self.cal_fixed_flag = True # whether we need to calculate the temp varaiables this time.
         self.show_flow = False # default false. Do not change it to be true, it is computation-heavy.
         self.flow_srcs = None # Indicating the flow src(pixles in non-masked region that will shift into the masked region)
 
@@ -26,13 +24,9 @@ class InnerShiftTriple(nn.Module):
     def forward(self, input):
         #print(input.shape)
         _, self.c, self.h, self.w = input.size()
-        if self.fixed_mask and self.cal_fixed_flag == False:
-            assert torch.is_tensor(self.flag), 'flag must have been figured out and has to be a tensor!'
-        else:
-            latter = input.narrow(1, self.c//2, self.c//2).narrow(0,0,1).detach()
-            self.flag = util.cal_flag_given_mask_thred(latter.squeeze(), self.mask, self.shift_sz, \
-                                                                                                   self.stride, self.mask_thred)
-            self.cal_fixed_flag = False
+        latter = input.narrow(1, self.c//2, self.c//2).narrow(0,0,1).detach()
+        self.flag = util.cal_flag_given_mask_thred(latter.squeeze(), self.mask, self.shift_sz, \
+                                                                                                self.stride, self.mask_thred)
 
         final_out = InnerShiftTripleFunction.apply(input, self.mask, self.shift_sz, self.stride, self.triple_weight, self.flag, self.show_flow)
         if self.show_flow:

--- a/models/shift_net/shiftnet_model.py
+++ b/models/shift_net/shiftnet_model.py
@@ -53,8 +53,6 @@ class ShiftNetModel(BaseModel):
         self.mask_type = opt.mask_type
         self.gMask_opts = {}
 
-        if self.mask_type == 'random':
-            self.create_random_mask()
 
         self.wgan_gp = False
         # added for wgan-gp
@@ -147,23 +145,7 @@ class ShiftNetModel(BaseModel):
         self.real_A = real_A
         self.real_B = real_B
         self.image_paths = input['A_paths']
-
-    # TODO: it has not been implemented totally.
-    def set_input_with_mask(self, input, mask):
-        real_A = input['A'].to(self.device)
-        real_B = input['B'].to(self.device)
-
-        self.mask_global = mask
-
-        self.set_latent_mask(mask, 3)
-
-        real_A.narrow(1,0,1).masked_fill_(mask, 0.)#2*123.0/255.0 - 1.0
-        real_A.narrow(1,1,1).masked_fill_(mask, 0.)#2*104.0/255.0 - 1.0
-        real_A.narrow(1,2,1).masked_fill_(mask, 0.)#2*117.0/255.0 - 1.0
-
-        self.real_A = real_A
-        self.real_B = real_B
-        self.image_paths = input['A_paths']       
+    
 
     def set_latent_mask(self, mask_global, layer_to_last):
         for ng_shift in self.ng_shift_list: # ITERATE OVER THE LIST OF ng_shift_list

--- a/models/shift_net/shiftnet_model.py
+++ b/models/shift_net/shiftnet_model.py
@@ -52,9 +52,6 @@ class ShiftNetModel(BaseModel):
 
         self.mask_type = opt.mask_type
         self.gMask_opts = {}
-        self.fixed_mask = opt.fixed_mask if opt.mask_type == 'center' else 0
-        if opt.mask_type == 'center':
-            assert opt.fixed_mask == 1, "Center mask must be fixed mask!"
 
         if self.mask_type == 'random':
             self.create_random_mask()
@@ -125,18 +122,14 @@ class ShiftNetModel(BaseModel):
         real_B = input['B'].to(self.device)
 
         # Add mask to real_A
-        # When the mask is random, or the mask is not fixed, we all need to create_gMask
-        if self.fixed_mask:
-            if self.opt.mask_type == 'center':
-                self.mask_global.zero_()
-                self.mask_global[:, :, int(self.opt.fineSize/4) + self.opt.overlap : int(self.opt.fineSize/2) + int(self.opt.fineSize/4) - self.opt.overlap,\
-                                    int(self.opt.fineSize/4) + self.opt.overlap: int(self.opt.fineSize/2) + int(self.opt.fineSize/4) - self.opt.overlap] = 1
-            elif self.opt.mask_type == 'random':
-                self.mask_global = self.create_random_mask().type_as(self.mask_global)
-            else:
-                raise ValueError("Mask_type [%s] not recognized." % self.opt.mask_type)
-        else:
+        if self.opt.mask_type == 'center':
+            self.mask_global.zero_()
+            self.mask_global[:, :, int(self.opt.fineSize/4) + self.opt.overlap : int(self.opt.fineSize/2) + int(self.opt.fineSize/4) - self.opt.overlap,\
+                                int(self.opt.fineSize/4) + self.opt.overlap: int(self.opt.fineSize/2) + int(self.opt.fineSize/4) - self.opt.overlap] = 1
+        elif self.opt.mask_type == 'random':
             self.mask_global = self.create_random_mask().type_as(self.mask_global)
+        else:
+            raise ValueError("Mask_type [%s] not recognized." % self.opt.mask_type)
 
         self.set_latent_mask(self.mask_global, 3)
 

--- a/models/soft_shift_net/innerSoftShiftTriple.py
+++ b/models/soft_shift_net/innerSoftShiftTriple.py
@@ -24,9 +24,7 @@ class InnerSoftShiftTriple(nn.Module):
     # If mask changes, then need to set cal_fix_flag true each iteration.
     def forward(self, input):
         _, self.c, self.h, self.w = input.size()
-        latter = input.narrow(1, self.c//2, self.c//2).narrow(0,0,1).detach()
-        self.flag = util.cal_flag_given_mask_thred(latter.squeeze(), self.mask, self.shift_sz, \
-                                                                                self.stride, self.mask_thred)
+        self.flag = util.cal_flag_given_mask_thred(self.mask, self.shift_sz, self.stride, self.mask_thred)
 
         final_out = self.softShift(input, self.mask, self.stride, self.triple_weight, self.flag, self.show_flow)
         if self.show_flow:

--- a/models/soft_shift_net/innerSoftShiftTriple.py
+++ b/models/soft_shift_net/innerSoftShiftTriple.py
@@ -5,15 +5,13 @@ from .innerSoftShiftTripleModule import InnerSoftShiftTripleModule
 
 
 class InnerSoftShiftTriple(nn.Module):
-    def __init__(self, fixed_mask, shift_sz=1, stride=1, mask_thred=1, triple_weight=1):
+    def __init__(self, shift_sz=1, stride=1, mask_thred=1, triple_weight=1):
         super(InnerSoftShiftTriple, self).__init__()
-        self.fixed_mask = fixed_mask
 
         self.shift_sz = shift_sz
         self.stride = stride
         self.mask_thred = mask_thred
         self.triple_weight = triple_weight
-        self.cal_fixed_flag = True # whether we need to calculate the temp varaiables this time.
         self.show_flow = False # default false. Do not change it to be true, it is computation-heavy.
         self.flow_srcs = None # Indicating the flow src(pixles in non-masked region that will shift into the masked region)
         self.softShift = InnerSoftShiftTripleModule()
@@ -26,13 +24,10 @@ class InnerSoftShiftTriple(nn.Module):
     # If mask changes, then need to set cal_fix_flag true each iteration.
     def forward(self, input):
         _, self.c, self.h, self.w = input.size()
-        if self.fixed_mask and self.cal_fixed_flag == False:
-            assert torch.is_tensor(self.flag), 'flag must have been figured out and has to be a tensor!'
-        else:
-            latter = input.narrow(1, self.c//2, self.c//2).narrow(0,0,1).detach()
-            self.flag = util.cal_flag_given_mask_thred(latter.squeeze(), self.mask, self.shift_sz, \
-                                                                                  self.stride, self.mask_thred)
-            self.cal_fixed_flag = False
+        latter = input.narrow(1, self.c//2, self.c//2).narrow(0,0,1).detach()
+        self.flag = util.cal_flag_given_mask_thred(latter.squeeze(), self.mask, self.shift_sz, \
+                                                                                self.stride, self.mask_thred)
+
         final_out = self.softShift(input, self.mask, self.stride, self.triple_weight, self.flag, self.show_flow)
         if self.show_flow:
             self.flow_srcs = self.softShift.get_flow_src()

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -44,8 +44,6 @@ class BaseOptions():
                             help='the type of mask you want to apply, \'center\' or \'random\'')
         parser.add_argument('--mask_sub_type', type=str, default='island',
                             help='the type of mask you want to apply, \'rect \' or \'fractal \ or \'island \'')
-
-        parser.add_argument('--fixed_mask', type=int, default=1, help='1 or 0, whether mask is fixed')
         parser.add_argument('--lambda_A', type=int, default=100, help='weight on L1 term in objective')
         parser.add_argument('--stride', type=int, default=1, help='should be dense, 1 is a good option.')
         parser.add_argument('--shift_sz', type=int, default=1, help='shift_sz>1 only for \'soft_shift_patch\'.')

--- a/util/util.py
+++ b/util/util.py
@@ -210,7 +210,6 @@ def cal_feat_mask(inMask, nlayers):
     inMask = inMask.float()
     ntimes = 2**nlayers
     inMask = F.interpolate(inMask, (inMask.size(2)//ntimes, inMask.size(3)//ntimes), mode='nearest')
-    inMask = (inMask > 0.5).float()
     inMask = inMask.detach().byte()
 
     return inMask

--- a/util/util.py
+++ b/util/util.py
@@ -215,8 +215,7 @@ def cal_feat_mask(inMask, nlayers):
     return inMask
 
 # It is only for patch_size=1 for now.
-def cal_flag_given_mask_thred(img, mask, patch_size, stride, mask_thred):
-    assert img.dim() == 3, 'img has to be 3 dimenison!'
+def cal_flag_given_mask_thred(mask, patch_size, stride, mask_thred):
     assert mask.dim() == 2, 'mask has to be 2 dimenison!'
 
     mask = mask.float()


### PR DESCRIPTION
In original code, fixed_mask is a redundant option to reduce quite minor computation(less than 0.5ms) when mask is fixed. So I delete it as it is quite misleading.