### PR TITLE
fix guidance loss bug when using random mask

### DIFF
--- a/models/modules/shift_unet.py
+++ b/models/modules/shift_unet.py
@@ -82,7 +82,7 @@ class UnetSkipConnectionShiftBlock(nn.Module):
         shift = InnerShiftTriple(opt.shift_sz, opt.stride, opt.mask_thred,
                                             opt.triple_weight, layer_to_last=layer_to_last)
 
-        shift.set_mask(mask_global, 3)
+        shift.set_mask(mask_global)
         shift_list.append(shift)
 
         # Add latent constraint
@@ -197,7 +197,7 @@ class ResUnetSkipConnectionBlock(nn.Module):
         shift = InnerResShiftTriple(inner_nc, opt.shift_sz, opt.stride, opt.mask_thred,
                                             opt.triple_weight, layer_to_last=layer_to_last)
 
-        shift.set_mask(mask_global, 3)
+        shift.set_mask(mask_global)
         shift_list.append(shift)
 
         # Add latent constraint
@@ -424,7 +424,7 @@ class PatchSoftUnetSkipConnectionShiftTriple(nn.Module):
         shift = InnerPatchSoftShiftTriple(opt.shift_sz, opt.stride, opt.mask_thred,
                                             opt.triple_weight, opt.fuse, layer_to_last=layer_to_last)
 
-        shift.set_mask(mask_global, 3)
+        shift.set_mask(mask_global)
         shift_list.append(shift)
 
         # Add latent constraint
@@ -540,7 +540,7 @@ class ResPatchSoftUnetSkipConnectionShiftTriple(nn.Module):
         shift = InnerResPatchSoftShiftTriple(inner_nc, opt.shift_sz, opt.stride, opt.mask_thred,
                                             opt.triple_weight, opt.fuse, layer_to_last=layer_to_last)
 
-        shift.set_mask(mask_global, 3)
+        shift.set_mask(mask_global)
         shift_list.append(shift)
 
         # Add latent constraint
@@ -710,7 +710,7 @@ class InceptionShiftUnetSkipConnectionBlock(nn.Module):
             # So the shift define like this:
             shift = InnerShiftTriple(opt.shift_sz, opt.stride, opt.mask_thred, opt.triple_weight, layer_to_last=layer_to_last)
 
-            shift.set_mask(mask_global, 3)
+            shift.set_mask(mask_global)
             shift_list.append(shift)
 
             # Add latent constraint

--- a/models/shift_net/InnerShiftTriple.py
+++ b/models/shift_net/InnerShiftTriple.py
@@ -16,7 +16,7 @@ class InnerShiftTriple(nn.Module):
         self.flow_srcs = None # Indicating the flow src(pixles in non-masked region that will shift into the masked region)
 
 
-    def set_mask(self, mask_global, layer_to_last):
+    def set_mask(self, mask_global):
         mask = util.cal_feat_mask(mask_global, self.layer_to_last)
         self.mask = mask.squeeze()
         return self.mask

--- a/models/shift_net/shiftnet_model.py
+++ b/models/shift_net/shiftnet_model.py
@@ -155,6 +155,8 @@ class ShiftNetModel(BaseModel):
     def set_latent_mask(self, mask_global):
         for ng_shift in self.ng_shift_list: # ITERATE OVER THE LIST OF ng_shift_list
             ng_shift.set_mask(mask_global)
+        for ng_innerCos in self.ng_innerCos_list: # ITERATE OVER THE LIST OF ng_innerCos_list:
+            ng_innerCos.set_mask(mask_global)
 
     def set_gt_latent(self):
         if not self.opt.skip:
@@ -165,6 +167,7 @@ class ShiftNetModel(BaseModel):
             else:
                 real_B = self.real_B
             self.netG(real_B) # input ground truth
+
 
     def forward(self):
         self.fake_B = self.netG(self.real_A)


### PR DESCRIPTION
When using random mask, the guidance loss works on the initial mask instead of the newest mask. This PR fixes it.