### PR TITLE
Fix inner cos

### DIFF
--- a/models/shift_net/InnerCos.py
+++ b/models/shift_net/InnerCos.py
@@ -33,6 +33,12 @@ class InnerCos(nn.Module):
         if not self.skip:
             self.former = in_data.narrow(1, 0, self.c//2)
             self.former_in_mask = torch.mul(self.former, self.mask)
+            if len(self.target.size()) == 0: # For the first iteration.
+                self.target = self.target.expand_as(self.former_in_mask).type_as(self.former_in_mask)
+            
+            if self.former_in_mask.size() != self.target.size():  # For the last iteration of one epoch
+                self.target = self.target.narrow(0, 0, 1).expand_as(self.former_in_mask).type_as(self.former_in_mask)
+            
             # self.loss shuold put before self.target.
             # For each iteration, we input GT, then I. That means we get the self.target in the first forward. And in this forward, self.loss is dummy!
             # In the second forward, we input the corresponding I, then self.loss is working as expected. The self.target is the corresponding GT.

--- a/models/shift_net/InnerCos.py
+++ b/models/shift_net/InnerCos.py
@@ -42,7 +42,7 @@ class InnerCos(nn.Module):
             # self.loss shuold put before self.target.
             # For each iteration, we input GT, then I. That means we get the self.target in the first forward. And in this forward, self.loss is dummy!
             # In the second forward, we input the corresponding I, then self.loss is working as expected. The self.target is the corresponding GT.
-            self.loss = self.criterion(self.former_in_mask, self.target.expand_as(self.former_in_mask).type_as(self.former_in_mask))
+            self.loss = self.criterion(self.former_in_mask, self.target)
             self.target = in_data.narrow(1, self.c // 2, self.c // 2).detach() # the latter part
             self.target = self.target * self.strength
         else:


### PR DESCRIPTION
When the last iteration of one epoch, the target.size(1) is batchsize of previous iteration(which is batchSize in option.py), yet former_in_mask.size(1) is contains n with range of [1, batchSize], the expand_as cannot reduce the dimension. So it occurs an error.