### PR TITLE
add SN to densenet

### DIFF
--- a/models/modules/denset_net.py
+++ b/models/modules/denset_net.py
@@ -2,6 +2,7 @@ import re
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from .modules import *
 import torch.utils.model_zoo as model_zoo
 from collections import OrderedDict
 
@@ -16,14 +17,14 @@ model_urls = {
 }
 
 
-def densenet121(pretrained=False, **kwargs):
+def densenet121(pretrained=False, use_spectral_norm=True, **kwargs):
     r"""Densenet-121 model from
     `"Densely Connected Convolutional Networks" <https://arxiv.org/pdf/1608.06993.pdf>`_
 
     Args:
         pretrained (bool): If True, returns a model pre-trained on ImageNet
     """
-    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 24, 16),
+    model = DenseNet(num_init_features=64, growth_rate=32, block_config=(6, 12, 24, 16), use_spectral_norm=use_spectral_norm,
                      **kwargs)
     if pretrained:
         # '.'s are no longer allowed in module names, but pervious _DenseLayer
@@ -129,16 +130,16 @@ def densenet161(pretrained=False, **kwargs):
 
 
 class _DenseLayer(nn.Sequential):
-    def __init__(self, num_input_features, growth_rate, bn_size, drop_rate):
+    def __init__(self, num_input_features, growth_rate, bn_size, drop_rate, use_spectral_norm):
         super(_DenseLayer, self).__init__()
         self.add_module('norm1', nn.BatchNorm2d(num_input_features)),
         self.add_module('relu1', nn.ReLU()),
-        self.add_module('conv1', nn.Conv2d(num_input_features, bn_size *
-                        growth_rate, kernel_size=1, stride=1, bias=False)),
+        self.add_module('conv1', spectral_norm(nn.Conv2d(num_input_features, bn_size *
+                        growth_rate, kernel_size=1, stride=1, bias=False), use_spectral_norm)),
         self.add_module('norm2', nn.BatchNorm2d(bn_size * growth_rate)),
         self.add_module('relu2', nn.ReLU()),
-        self.add_module('conv2', nn.Conv2d(bn_size * growth_rate, growth_rate,
-                        kernel_size=3, stride=1, padding=1, bias=False)),
+        self.add_module('conv2', spectral_norm(nn.Conv2d(bn_size * growth_rate, growth_rate,
+                        kernel_size=3, stride=1, padding=1, bias=False), use_spectral_norm)),
         self.drop_rate = drop_rate
 
     def forward(self, x):
@@ -149,20 +150,20 @@ class _DenseLayer(nn.Sequential):
 
 
 class _DenseBlock(nn.Sequential):
-    def __init__(self, num_layers, num_input_features, bn_size, growth_rate, drop_rate):
+    def __init__(self, num_layers, num_input_features, bn_size, growth_rate, drop_rate, use_spectral_norm):
         super(_DenseBlock, self).__init__()
         for i in range(num_layers):
-            layer = _DenseLayer(num_input_features + i * growth_rate, growth_rate, bn_size, drop_rate)
+            layer = _DenseLayer(num_input_features + i * growth_rate, growth_rate, bn_size, drop_rate, use_spectral_norm)
             self.add_module('denselayer%d' % (i + 1), layer)
 
 
 class _Transition(nn.Sequential):
-    def __init__(self, num_input_features, num_output_features):
+    def __init__(self, num_input_features, num_output_features, use_spectral_norm):
         super(_Transition, self).__init__()
         self.add_module('norm', nn.BatchNorm2d(num_input_features))
         self.add_module('relu', nn.ReLU())
-        self.add_module('conv', nn.Conv2d(num_input_features, num_output_features,
-                                          kernel_size=1, stride=1, bias=False))
+        self.add_module('conv', spectral_norm(nn.Conv2d(num_input_features, num_output_features,
+                                          kernel_size=1, stride=1, bias=False), use_spectral_norm))
         self.add_module('pool', nn.AvgPool2d(kernel_size=2, stride=2))
 
 
@@ -179,14 +180,14 @@ class DenseNet(nn.Module):
         drop_rate (float) - dropout rate after each dense layer
         num_classes (int) - number of classification classes
     """
-    def __init__(self, growth_rate=32, block_config=(6, 12, 24, 16),
+    def __init__(self, growth_rate=32, block_config=(6, 12, 24, 16), use_spectral_norm=True,
                  num_init_features=64, bn_size=4, drop_rate=0, num_classes=1000):
 
         super(DenseNet, self).__init__()
 
         # First convolution
         self.features = nn.Sequential(OrderedDict([
-            ('conv0', nn.Conv2d(3, num_init_features, kernel_size=7, stride=2, padding=3, bias=False)),
+            ('conv0', spectral_norm(nn.Conv2d(3, num_init_features, kernel_size=7, stride=2, padding=3, bias=False), use_spectral_norm)),
             ('norm0', nn.BatchNorm2d(num_init_features)),
             ('relu0', nn.ReLU()),
             ('pool0', nn.MaxPool2d(kernel_size=3, stride=2, padding=1)),
@@ -196,18 +197,18 @@ class DenseNet(nn.Module):
         num_features = num_init_features
         for i, num_layers in enumerate(block_config):
             block = _DenseBlock(num_layers=num_layers, num_input_features=num_features,
-                                bn_size=bn_size, growth_rate=growth_rate, drop_rate=drop_rate)
+                                bn_size=bn_size, growth_rate=growth_rate, drop_rate=drop_rate, use_spectral_norm=use_spectral_norm)
             self.features.add_module('denseblock%d' % (i + 1), block)
             num_features = num_features + num_layers * growth_rate
             if i != len(block_config) - 1:
-                trans = _Transition(num_input_features=num_features, num_output_features=num_features // 2)
+                trans = _Transition(num_input_features=num_features, num_output_features=num_features // 2, use_spectral_norm=use_spectral_norm)
                 self.features.add_module('transition%d' % (i + 1), trans)
                 num_features = num_features // 2
 
         # Final batch norm
         self.features.add_module('norm5', nn.BatchNorm2d(num_features))
 
-        self.conv_last = nn.Conv2d(num_features, 256, kernel_size=3)
+        self.conv_last = spectral_norm(nn.Conv2d(num_features, 256, kernel_size=3), use_spectral_norm)
 
         # Linear layer
         # self.classifier = nn.Linear(num_features, num_classes)

--- a/models/modules/discrimators.py
+++ b/models/modules/discrimators.py
@@ -53,9 +53,9 @@ class NLayerDiscriminator(nn.Module):
 
 # Defines a densetnet inspired discriminator (Should improve its ability to create stronger representation)
 class DenseNetDiscrimator(nn.Module):
-    def __init__(self, input_nc, ndf=64, n_layers=3, norm_layer=nn.BatchNorm2d, use_sigmoid=False):
+    def __init__(self, input_nc, ndf=64, n_layers=3, norm_layer=nn.BatchNorm2d, use_sigmoid=False, use_spectral_norm=True):
         super(DenseNetDiscrimator, self).__init__()
-        self.model = densenet121(pretrained=True)
+        self.model = densenet121(pretrained=True, use_spectral_norm=use_spectral_norm)
         self.use_sigmoid = use_sigmoid
         if self.use_sigmoid:
             self.sigmoid = nn.Sigmoid()

--- a/models/networks.py
+++ b/models/networks.py
@@ -133,8 +133,7 @@ def define_D(input_nc, ndf, which_model_netD,
         netD = NLayerDiscriminator(input_nc, ndf, n_layers_D, norm_layer=norm_layer, use_sigmoid=use_sigmoid, use_spectral_norm=use_spectral_norm)
 
     elif which_model_netD == 'densenet':
-        # haven't implemented SN for densenet
-        netD = DenseNetDiscrimator(input_nc, ndf, n_layers=3, norm_layer=norm_layer, use_sigmoid=use_sigmoid)
+        netD = DenseNetDiscrimator(input_nc, ndf, n_layers=3, norm_layer=norm_layer, use_sigmoid=use_sigmoid, use_spectral_norm=use_spectral_norm)
 
     else:
         print('Discriminator model name [%s] is not recognized' %


### PR DESCRIPTION
When D is 'basic', adding spectral_norm to D makes the artifacts less and more semantic structures appear.
So I also add SN to densenet, always you can remove SN by setting `use_spectral_norm_D=0`.